### PR TITLE
fix: 默认跟随系统主题 + 修复首次加载闪烁问题

### DIFF
--- a/packages/dashboard/client/lib/theme-context.tsx
+++ b/packages/dashboard/client/lib/theme-context.tsx
@@ -8,21 +8,47 @@ interface ThemeContextType {
   setTheme: (t: Theme) => void;
 }
 
+/**
+ * Resolve the actual theme based on user preference and system setting.
+ * Runs synchronously to avoid flash of wrong theme on initial render.
+ */
+function getInitialTheme(): { theme: Theme; resolved: 'light' | 'dark' } {
+  // Check localStorage first (only in browser)
+  if (typeof window === 'undefined') {
+    return { theme: 'system', resolved: 'dark' };
+  }
+
+  const saved = localStorage.getItem('ccm-theme') as Theme | null;
+  const theme = saved ?? 'system';
+
+  // Resolve based on saved preference or system
+  if (theme === 'system') {
+    const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+    return { theme, resolved: prefersDark ? 'dark' : 'light' };
+  }
+
+  return { theme, resolved: theme };
+}
+
+// Initialize synchronously to avoid theme flash
+const initial = getInitialTheme();
+
+// Apply theme immediately before React hydrates (prevents flash)
+if (typeof document !== 'undefined') {
+  document.documentElement.setAttribute('data-theme', initial.resolved);
+}
+
 const ThemeContext = createContext<ThemeContextType>({
-  theme: 'system',
-  resolvedTheme: 'dark',
+  theme: initial.theme,
+  resolvedTheme: initial.resolved,
   setTheme: () => {},
 });
 
 export function ThemeProvider({ children }: { children: React.ReactNode }) {
-  const [theme, setThemeState] = useState<Theme>('system');
-  const [resolvedTheme, setResolved] = useState<'light' | 'dark'>('dark');
+  const [theme, setThemeState] = useState<Theme>(initial.theme);
+  const [resolvedTheme, setResolved] = useState<'light' | 'dark'>(initial.resolved);
 
-  useEffect(() => {
-    const saved = localStorage.getItem('ccm-theme') as Theme | null;
-    if (saved) setThemeState(saved);
-  }, []);
-
+  // Listen for system theme changes when in 'system' mode
   useEffect(() => {
     localStorage.setItem('ccm-theme', theme);
 
@@ -37,6 +63,7 @@ export function ThemeProvider({ children }: { children: React.ReactNode }) {
     return undefined;
   }, [theme]);
 
+  // Apply theme to document
   useEffect(() => {
     document.documentElement.setAttribute('data-theme', resolvedTheme);
   }, [resolvedTheme]);


### PR DESCRIPTION
## 问题

当前主题实现存在两个问题：

1. **首次访问默认 dark** — 即使用户系统是 light 模式，首次访问时会看到 dark 主题
2. **FOUC (Flash of Unstyled Content)** — 如果用户之前选择了 light 主题，页面加载时会先闪一下 dark 再变 light

## 修复

1. **同步初始化** — 在 React hydrate 之前就读取 localStorage 和系统主题偏好
2. **立即应用 `data-theme`** — 模块加载时就设置 `document.documentElement.setAttribute`，避免闪烁
3. **默认 `system`** — 新用户首次访问时自动跟随系统主题

## 代码变更

```typescript
// 之前：异步初始化，默认 dark
const [theme, setThemeState] = useState<Theme>("system");
const [resolvedTheme, setResolved] = useState<"light" | "dark">("dark");

// 之后：同步初始化，立即解析系统主题
function getInitialTheme(): { theme: Theme; resolved: "light" | "dark" } {
  const saved = localStorage.getItem("ccm-theme") as Theme | null;
  const theme = saved ?? "system";
  
  if (theme === "system") {
    const prefersDark = window.matchMedia("(prefers-color-scheme: dark)").matches;
    return { theme, resolved: prefersDark ? "dark" : "light" };
  }
  return { theme, resolved: theme };
}

const initial = getInitialTheme();

// 在 React 渲染前就应用主题
if (typeof document !== "undefined") {
  document.documentElement.setAttribute("data-theme", initial.resolved);
}
```

## 测试

- [x] macOS light mode → 首次访问显示 light 主题
- [x] macOS dark mode → 首次访问显示 dark 主题
- [x] 切换系统主题 → 实时响应（当选择 system 时）
- [x] 手动选择 dark/light → 保存到 localStorage，下次访问保持

---

Related to #2 (Code Review Issue)