### PR TITLE
docs: add Chinese README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+**English** · [简体中文](README.zh.md)
+
+---
+
 # claude-config-manager
 
 A Claude Code plugin that gives you a web dashboard + CLI to manage your whole Claude Code setup: plugins, MCP servers, skills, commands, settings, profiles, sessions, and usage metrics.

--- a/README.zh.md
+++ b/README.zh.md
@@ -1,0 +1,186 @@
+[English](README.md) · **简体中文**
+
+---
+
+# claude-config-manager
+
+一个 Claude Code 插件，给你一套 Web Dashboard + CLI 来管理整套 Claude Code 配置：插件、MCP 服务器、skill、命令、设置、配置档案、会话、使用指标。
+
+## 安装
+
+```bash
+# 1. 添加市场
+claude plugin marketplace add https://github.com/wangcansunking/can-claude-plugins
+
+# 2. 安装插件
+claude plugin install claude-config-manager@can-claude-plugins
+
+# 3. 在任意 Claude Code 会话里打开 dashboard
+/ccm-dashboard
+```
+
+Dashboard 会在 <http://localhost:3399> 启动，并自动在浏览器里打开。
+
+![Dashboard 总览](docs/migration/screenshots/01-dashboard-overview.png)
+
+## 为什么
+
+Claude Code 的可配置表面很大 — `settings.json`、MCP 配置、插件市场、skill、命令、hook、环境变量、会话。手改 JSON 能 work，但一旦要在多个项目之间切换、或者要复用一套配置，就很难规模化。`claude-config-manager` 提供：
+
+- 一处查看和编辑所有 Claude Code 配置文件
+- 可导出、导入、激活的配置档案快照（想像成 Claude 的 `nvm use`）
+- 浏览插件、MCP 服务器、skill 的市场视图
+- 实时会话活动，一键恢复
+- 从本地 Claude Code 历史中提取的使用指标
+
+## 功能
+
+### 总览和使用指标
+
+首页展示已安装插件、MCP 服务器、最近会话、token 消耗图、环境健康 — 一眼尽览。
+
+![MCP 使用图表](docs/migration/screenshots/01b-dashboard-mcp-usage.png)
+
+### 个性化推荐
+
+针对当前配置运行 `/ccm-recommendations`，推荐你还没装的插件、MCP 服务器、skill。
+
+![推荐](docs/migration/screenshots/02-recommended.png)
+
+### 插件管理
+
+查看已安装的插件、浏览市场、进入插件详情查看它的命令、skill、MCP 服务器。
+
+![已安装插件](docs/migration/screenshots/03-config-plugins-installed.png)
+![插件详情面板](docs/migration/screenshots/03b-plugin-detail-panel.png)
+![插件市场](docs/migration/screenshots/03c-plugins-marketplace.png)
+
+### MCP 服务器管理
+
+添加、移除、查看 MCP 服务器。MCP 市场让你一键安装常用服务。
+
+![已安装 MCP](docs/migration/screenshots/04-config-mcp-installed.png)
+![MCP 市场](docs/migration/screenshots/04c-mcp-store.png)
+
+### Skill、命令与设置
+
+在全屏阅读器中编辑 skill markdown、管理 slash command、无需打开编辑器调整 `settings.json`（model、hooks、env var）。
+
+![Skill 标签页](docs/migration/screenshots/05-config-skills.png)
+![设置标签页](docs/migration/screenshots/07-config-settings.png)
+
+### 配置档案（导出 / 导入 / 激活）
+
+把完整配置 — 插件、MCP 服务器、skill、命令、hook、设置 — 快照到一个命名的配置档案里。切档案就切整套配置；导出成 `.json` 可分享给同事。
+
+![配置档案](docs/migration/screenshots/08-profiles.png)
+![导出 / 导入](docs/migration/screenshots/08b-profiles-export-import.png)
+
+### 会话活动
+
+跨所有项目浏览历史与正在运行的 Claude Code 会话。点击任意会话查看历史；一键复制 `claude --resume <id>` 恢复。
+
+![活动](docs/migration/screenshots/09-activity.png)
+![会话详情](docs/migration/screenshots/09b-activity-session-detail.png)
+
+### 暗色 / 亮色主题
+
+![暗色](docs/migration/screenshots/10-dark-mode.png)
+![亮色](docs/migration/screenshots/10b-light-mode.png)
+
+## Slash 命令
+
+| 命令 | 作用 |
+|------|------|
+| `/ccm` | 快捷入口 — 状态、配置档案、打开 dashboard |
+| `/ccm-dashboard` | 启动 dashboard 并在浏览器打开 |
+| `/ccm-export` | 把当前配置导出成档案 JSON |
+| `/ccm-import` | 导入档案 JSON 并激活 |
+| `/ccm-profile` | 列出、创建、切换、删除配置档案 |
+
+## Skill
+
+| Skill | 作用 |
+|-------|------|
+| `ccm-dashboard` | 启动并打开 dashboard |
+| `ccm-recommendations` | 基于当前配置刷新"推荐"页的个性化建议 |
+
+## MCP 工具
+
+只暴露 **2 个工具** — 刻意极简，避免抢占 model 的工具选择面：
+
+| 工具 | 作用 |
+|------|------|
+| `ccm_dashboard_status` | 只读：dashboard 是否运行、端口、PID |
+| `ccm_open_dashboard`   | 返回 dashboard URL + 启动提示 |
+
+其他所有功能（配置档案、插件、MCP、skill、命令、设置）全部通过 **`claude-config` CLI** 流转 — CLI 是操作层的唯一真实来源。`/ccm-*` slash 命令通过 Bash 调用 CLI。
+
+## CLI
+
+```bash
+node packages/cli/dist/index.js --help    # 或作为插件：node ${CLAUDE_PLUGIN_ROOT}/packages/cli/dist/index.js
+```
+
+提供的命令面：
+
+```
+claude-config start [--port <port>] [--no-open]
+claude-config list [--plugins | --mcps | --skills | --commands] [--json]
+claude-config profile list [--json]
+claude-config profile create <name>
+claude-config profile activate <name>
+claude-config profile delete <name>
+claude-config export <profile> [--output <file>] [--format json|yaml]
+claude-config import <file> [--replace] [--activate] [--dry-run]
+claude-config gist push <profile> [--description <d>] [--public] [--dry-run]
+claude-config gist pull <id-or-url> [--activate] [--replace]
+claude-config mcp-server                  # 以 stdio 形式运行 MCP server
+```
+
+## 仓库结构
+
+```
+claude-config-manager/
+  .claude-plugin/plugin.json         插件元数据
+  .mcp.json                          MCP server 接线
+  mcp-entry.mjs                      MCP server 入口
+  commands/                          Slash command（Skill.md）
+  skills/                            Skill（Skill.md）
+  hooks/                             Claude Code hook 脚本
+  packages/
+    types/                           共享 TypeScript 类型
+    core/                            业务逻辑（档案、扫描器、管理器）
+    mcp/                             MCP server（2 个工具 — dashboard 状态 + 打开）
+    dashboard/                       Express + Vite Dashboard（UI + API）
+    cli/                             `claude-config` CLI
+  docs/                              规格文档和截图
+```
+
+## 开发
+
+从源码开始：
+
+```bash
+git clone https://github.com/wangcansunking/claude-config-manager
+cd claude-config-manager
+npm install
+npm run dev                 # 跨所有 package 的 turbo dev
+```
+
+其他脚本：
+
+```bash
+npm run build
+npm run test                # Vitest 单元测试
+npm run test:e2e            # Playwright E2E
+npm run type-check
+npm run lint
+npm start                   # 启动构建好的 dashboard（:3399）
+```
+
+Dashboard 的开发 server 跑在 `:3399`，由 `turbo dev` 负责。
+
+## Changelog
+
+见 [CHANGELOG.md](CHANGELOG.md)。


### PR DESCRIPTION
Adds `README.zh.md` and a bilingual header at the top of both `README.md` and `README.zh.md`. Content mirrors the English one — install commands, CLI surface, screenshot paths, and repository layout are identical; only narrative text, section headings, and table headers are translated.

The Chinese CLI reference also includes the `gist push`/`gist pull` commands that landed in PR #5, so the zh-surface is a complete mirror rather than a subset.

## Changelog

### Added
- `README.zh.md` — 简体中文 translation of the claude-config-manager README.
- Bilingual header on both README files with a one-click language toggle.