### PR TITLE
chore(dashboard): add theme-color meta matching favicon

### DIFF
--- a/packages/dashboard/dist/client/index.html
+++ b/packages/dashboard/dist/client/index.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Claude Config Manager</title>
   <meta name="description" content="Manage your Claude configuration, plugins, MCP servers, and more." />
+  <meta name="theme-color" content="#D97757" />
   <link rel="icon" type="image/x-icon" href="/favicon.ico" />
   <link rel="icon" type="image/png" sizes="32x32" href="/icon-32.png" />
   <link rel="icon" type="image/png" sizes="192x192" href="/icon-192.png" />

--- a/packages/dashboard/index.html
+++ b/packages/dashboard/index.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Claude Config Manager</title>
   <meta name="description" content="Manage your Claude configuration, plugins, MCP servers, and more." />
+  <meta name="theme-color" content="#D97757" />
   <link rel="icon" type="image/x-icon" href="/favicon.ico" />
   <link rel="icon" type="image/png" sizes="32x32" href="/icon-32.png" />
   <link rel="icon" type="image/png" sizes="192x192" href="/icon-192.png" />


### PR DESCRIPTION
## Summary

Adds `<meta name="theme-color" content="#D97757" />` to the dashboard's `index.html`, matching the terracotta favicon shipped in 1.1.1. On mobile browsers (Safari iOS, Chrome Android) this colors the address bar, so the tab and browser chrome both read as part of the same app.

Also serves as the first end-to-end validation of the auto-bump workflow activated in #7: expected behavior on merge is (a) `.github/workflows/auto-bump.yml` bumps 1.1.1 → 1.1.2 across all version files + prepends this `## Changelog` block to CHANGELOG.md + pushes `v1.1.2` tag, and (b) `bump-marketplace.mjs` opens a companion PR on `can-claude-plugins`.

## Changelog

### Added
- **`theme-color` meta tag on dashboard.** `<meta name="theme-color" content="#D97757">` added to `index.html`, matching the terracotta favicon from 1.1.1. Mobile browsers (iOS Safari, Chrome Android) use this to tint the address bar / status bar area so the dashboard reads as a branded app rather than a raw page.

## Test plan

- [x] Source + `dist/client/index.html` both contain the new meta tag.
- [x] `npm run build --workspace=@ccm/dashboard` clean.
- [ ] After merge: verify auto-bump action succeeds, v1.1.2 tag pushed, and a companion PR appears at `wangcansunking/can-claude-plugins`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)